### PR TITLE
update gene mapping url, remove now unnecessary makefile code

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ _Note: If running on a Windows machine, replace `sh odk.sh` with `odk.bat` in th
 
 This project was made with the
 [mapping-commons-cookiecutter](https://github.com/mapping-commons/mapping-commons-cookiecutter).
+

--- a/monarch_mapping_commons.Makefile
+++ b/monarch_mapping_commons.Makefile
@@ -27,5 +27,5 @@ $(MAPPING_DIR)/mesh_chebi_biomappings.sssom.tsv:
 
 $(MAPPING_DIR)/gene_mappings.sssom.tsv:
 	mkdir -p $(MAPPING_DIR) $(TMP_DIR)
-	wget http://data.monarchinitiative.org/monarch-gene-mapping/latest/gene_mappings.tsv -O $(TMP_DIR)/gene_mappings.sssom.tsv
+	wget http://data.monarchinitiative.org/monarch-gene-mapping/latest/gene_mappings.sssom.tsv -O $(TMP_DIR)/gene_mappings.sssom.tsv
 	sssom parse $(TMP_DIR)/gene_mappings.sssom.tsv -m $(METADATA_DIR)/gene_mappings.sssom.yml --prefix-map-mode merged -o $@

--- a/monarch_mapping_commons.Makefile
+++ b/monarch_mapping_commons.Makefile
@@ -28,7 +28,4 @@ $(MAPPING_DIR)/mesh_chebi_biomappings.sssom.tsv:
 $(MAPPING_DIR)/gene_mappings.sssom.tsv:
 	mkdir -p $(MAPPING_DIR) $(TMP_DIR)
 	wget http://data.monarchinitiative.org/monarch-gene-mapping/latest/gene_mappings.tsv -O $(TMP_DIR)/gene_mappings.sssom.tsv
-	# see https://github.com/monarch-initiative/monarch-mapping-commons/issues/33
-	grep -v "<NA>" $(TMP_DIR)/gene_mappings.sssom.tsv > $@.tmp && mv $@.tmp $(TMP_DIR)/gene_mappings.sssom.tsv
-	grep -v ";" $(TMP_DIR)/gene_mappings.sssom.tsv > $@.tmp && mv $@.tmp $(TMP_DIR)/gene_mappings.sssom.tsv
 	sssom parse $(TMP_DIR)/gene_mappings.sssom.tsv -m $(METADATA_DIR)/gene_mappings.sssom.yml --prefix-map-mode merged -o $@

--- a/registry.yml
+++ b/registry.yml
@@ -23,5 +23,5 @@ mapping_set_references:
   - mapping_set_id: http://w3id.org/sssom/commons/monarch/gene_mappings.sssom.tsv
     mapping_set_group: gene_mappings
     local_name: gene_mappings.sssom.tsv
-    mirror_from: http://data.monarchinitiative.org/monarch-gene-mapping/latest/gene_mappings.tsv
+    mirror_from: http://data.monarchinitiative.org/monarch-gene-mapping/latest/gene_mappings.sssom.tsv
     mapping_set_confidence: "0.9"

--- a/registry.yml
+++ b/registry.yml
@@ -23,5 +23,5 @@ mapping_set_references:
   - mapping_set_id: http://w3id.org/sssom/commons/monarch/gene_mappings.sssom.tsv
     mapping_set_group: gene_mappings
     local_name: gene_mappings.sssom.tsv
-    mirror_from: http://data.monarchinitiative.org/monarch-gene-mapping/latest/gene_mappings.sssom.tsv
+    mirror_from: https://data.monarchinitiative.org/monarch-gene-mapping/latest/gene_mappings.sssom.tsv
     mapping_set_confidence: "0.9"


### PR DESCRIPTION
Closes #37 and #33

Latest release of https://github.com/monarch-initiative/monarch-gene-mapping/ splits rows which contain semicolons into multiple rows, as well as removing rows with empty column values. 

Unfortunately 1:n mappings is a separate issue that can't easily be resolved in a PR like this, but the other issues mentioned in #33 are resolved