### PR TITLE
Adds NCBI to PomBase gene mappings

### DIFF
--- a/src/monarch_gene_mapping/download.yaml
+++ b/src/monarch_gene_mapping/download.yaml
@@ -16,6 +16,14 @@
   url: https://ftp.ncbi.nih.gov/gene/DATA/gene2ensembl.gz
   local_name: data/ncbi/gene2ensembl.gz
   tag: ncbi
+-
+  url: https://ftp.ncbi.nih.gov/gene/DATA/gene_info.gz
+  local_name: data/ncbi/gene_info.gz
+  tag: ncbi
+-
+  url: https://www.pombase.org/data/names_and_identifiers/gene_IDs_names_products.tsv
+  local_name: data/pombase/gene_IDs_names_products.tsv
+  tag: pombase
 
   # UniProtKB - caution! the original UniProt file is a *huge* 11 GB archive file!
   # This file may be prefiltered down to target species using the 'uniprot_idmapping_preprocess.py' script:


### PR DESCRIPTION
Brings in NCBI's gene_info file so that the NCBI Gene ID and LocusTag columns can be used to create SSSOM mappings between gene curies. Prefixing the LocusTag column with PomBase: creates some identifiers that aren't actually valid PomBase IDs, so PomBase's gene info file is used to confirm that we only make mappings to valid gene identifiers.
