### PR TITLE
swapped to keeping CHEBI-mesh mappings, then flip and keep mesh-CHEBI mappings

### DIFF
--- a/scripts/process_biomappings.py
+++ b/scripts/process_biomappings.py
@@ -35,21 +35,39 @@ def main(input: str, output: Path):
     # Remove negative mappings
     df = df[df["predicate_modifier"] != "Not"]
 
+    # Capture MESH to ChEBI rows
+    df_to_flip = df[(df["subject_id"].str.startswith("mesh"))
+                    & (df["object_id"].str.startswith("CHEBI"))
+                    & (df["predicate_id"] == "skos:exactMatch")]
+
     # Get only ChEBI to MESH rows
-    df = df[(df["subject_id"].str.startswith("mesh")) & (df["object_id"].str.startswith("CHEBI"))]
+    df = df[(df["subject_id"].str.startswith("CHEBI"))
+            & (df["object_id"].str.startswith("mesh"))
+            & (df["predicate_id"] == "skos:exactMatch")]
 
-    # Convert subject_id to upper case
-    df["subject_id"] = df["subject_id"].str.upper()
+    # Flip the subject_id, subject_label and object_id, object_label columns on df_to_flip,
+    df_to_flip = df_to_flip.rename(columns={
+        "subject_id": "object_id",
+        "subject_label": "object_label",
+        "object_id": "subject_id",
+        "object_label": "subject_label"
+    })
+    # put the columns back into the original order
+    df_to_flip = df_to_flip[df.columns]
+    df = pd.concat([df, df_to_flip])
 
-    # Assert that all subject-IDs are MESH and all object-IDs are CHEBI
+    # Convert object_id (MESH) to upper case
+    df["object_id"] = df["object_id"].str.upper()
+
+    # Assert that all subject-IDs are CHEBI and all object-IDs are MESH
     assert all(
-        row.subject_id.__contains__("MESH") for row in df.itertuples()
+        row.subject_id.__contains__("CHEBI") for row in df.itertuples()
         # row.subject_id.__contains__("mesh") for row in df.itertuples()
-    ), f"\n\tSubject IDs are not all MESH: {df.subject_id.unique()}\n"
+    ), f"\n\tSubject IDs are not all CHEBI: {df.subject_id.unique()}\n"
 
     assert all(
-        row.object_id.__contains__("CHEBI") for row in df.itertuples()
-    ), f"\n\tObject IDs are not all CHEBI: {df.subject_id.unique()}\n"
+        row.object_id.__contains__("MESH") for row in df.itertuples()
+    ), f"\n\tObject IDs are not all MESH: {df.object_id.unique()}\n"
 
     subset = {
         key: metadata[key]


### PR DESCRIPTION
Monarch ingest had been missing CTD ingest rows for a while, since this was keeping mesh-CHEBI, rather than CHEBI-mesh. I was surprised to see that exactMappings in both directions existed in the file, so I kept CHEBI-mesh and then flipped the mesh-CHEBI to keep it as well. (being sure to only flip & keep exactMatch)
