### PR TITLE
Fix MESH prefix

### DIFF
--- a/metadata/mesh_chebi_biomappings.sssom.yml
+++ b/metadata/mesh_chebi_biomappings.sssom.yml
@@ -2,3 +2,6 @@ license: https://creativecommons.org/licenses/by/4.0/
 mapping_set_description: A subset of the biomappings containing mesh to chebi associations.
 mapping_set_id: https://data.monarchinitiative.org/mappings/mesh_chebi_biomappings.sssom.tsv
 mapping_set_source: https://w3id.org/biopragmatics/biomappings/sssom/biomappings.sssom.tsv
+curie_map:
+  MESH: http://identifiers.org/mesh
+  CHEBI: http://purl.obolibrary.org/obo/CHEBI_


### PR DESCRIPTION
Possibly overdoing it, checking the prefix after converting using the merged prefix map, also had to add a curie map metadata for the MESH & CHEBI prefixes to get around sssom parse assuming a different curie map. 