### PR TITLE
Update the URL for HGNC gene names

### DIFF
--- a/src/monarch_gene_mapping/download.yaml
+++ b/src/monarch_gene_mapping/download.yaml
@@ -7,7 +7,7 @@
 
 # HGNC
 -
-  url: http://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/hgnc_complete_set.txt
+  url: https://storage.googleapis.com/public-download-files/hgnc/tsv/tsv/hgnc_complete_set.txt
   local_name: data/hgnc/hgnc_complete_set.txt
   tag: hgnc_gene
 


### PR DESCRIPTION
Updated URL sourced from <https://www.genenames.org/download/archive/>

#### Resolves <https://github.com/monarch-initiative/monarch-app/issues/853>

- [x] I have verified `make mappings` still works correctly
- [ ] `docs/` have been added/updated, if needed

#### Description of changes
Updates the HGNC gene mappings URL as per <https://www.genenames.org/download/archive/>.