### PR TITLE
Improve docs about .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ data/
 tmp/
 *.pyc
 .DS_Store
+# there are a few files, e.g., hpo-snomed.sssom.tsv and
+# ncit-hp.sssom.tsv that have been force committed, because
+# these are the source of truth. Do not commit other derived
+# files here, like the one produced by scripts/process_biomappings.py
 mappings/*.sssom.tsv
 mappings/ttl
 data/

--- a/mappings/README.md
+++ b/mappings/README.md
@@ -1,5 +1,11 @@
 # Monarch mappings
 
+Source-of-truth mappings are stored in this folder.
+
+Scripts elsewhere in this repository may also choose to store their outputs in this folder,
+but they should not be committed. This is enforced by the `.gitignore` including a line
+excluding `mappings/*.sssom.tsv`.
+
 
 All Monarch related mappings are stored here:
 


### PR DESCRIPTION
This PR adds more explicit information about which mappings get committed in `/mappings` and why